### PR TITLE
Make Akavache.Sqlite3 a non-PCL library.

### DIFF
--- a/Akavache.Sqlite3/Akavache.Sqlite3.csproj
+++ b/Akavache.Sqlite3/Akavache.Sqlite3.csproj
@@ -13,12 +13,10 @@
     <AssemblyName>Akavache.Sqlite3</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
@@ -51,6 +49,7 @@
       <HintPath>..\..\..\packages\SQLitePCL.raw_basic.0.7.3.0-vs2012\lib\portable-net45+netcore45+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCL.raw.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=62aa029873c516b4, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Rx-Core.2.2.5-custom\lib\portable-net45+winrt45+wp8+wpa81\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
@@ -75,13 +74,13 @@
     <None Include="packages.Akavache.Sqlite3.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\splat\Splat\Splat-Portable.csproj">
-      <Project>{0ec8dba1-d745-4ee5-993a-6026440ec3bf}</Project>
-      <Name>Splat-Portable</Name>
+    <ProjectReference Include="..\..\splat\Splat\Splat-Net45.csproj">
+      <Project>{252ce1c2-027a-4445-a3c2-e4d6c80a935a}</Project>
+      <Name>Splat-Net45</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Akavache\Akavache_Portable.csproj">
-      <Project>{eb73addd-2fe9-44c0-a1ab-20709b979b64}</Project>
-      <Name>Akavache_Portable</Name>
+    <ProjectReference Include="..\Akavache\Akavache_Net45.csproj">
+      <Project>{b4e665e5-6caf-4414-a6e2-8de1c3bcf203}</Project>
+      <Name>Akavache_Net45</Name>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '12.0' ">
@@ -111,7 +110,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <WarningLevel>0</WarningLevel>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Akavache.Sqlite3/OperationQueue.cs
+++ b/Akavache.Sqlite3/OperationQueue.cs
@@ -1,21 +1,20 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Collections.Concurrent;
+using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
-using System.Reactive;
+using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Akavache.Sqlite3.Internal;
-using SQLitePCL;
 using Splat;
-
+using SQLitePCL;
 using AsyncLock = Akavache.Sqlite3.Internal.AsyncLock;
 
 namespace Akavache.Sqlite3
@@ -37,8 +36,8 @@ namespace Akavache.Sqlite3
         readonly BeginTransactionSqliteOperation begin;
         readonly CommitTransactionSqliteOperation commit;
 
-        BlockingCollection<OperationQueueItem> operationQueue =
-            new BlockingCollection<OperationQueueItem>();
+        Akavache.Sqlite3.Internal.BlockingCollection<OperationQueueItem> operationQueue =
+            new Akavache.Sqlite3.Internal.BlockingCollection<OperationQueueItem>();
 
         public SqliteOperationQueue(SQLiteConnection conn, IScheduler scheduler)
         {
@@ -161,7 +160,7 @@ namespace Akavache.Sqlite3
         // NB: Callers must hold flushLock to call this
         void FlushInternal()
         {
-            var newQueue = new BlockingCollection<OperationQueueItem>();
+            var newQueue = new Akavache.Sqlite3.Internal.BlockingCollection<OperationQueueItem>();
             var existingItems = Interlocked.Exchange(ref operationQueue, newQueue).ToList();
 
             ProcessItems(CoalesceOperations(existingItems));

--- a/Akavache/Akavache_Net45.csproj
+++ b/Akavache/Akavache_Net45.csproj
@@ -126,10 +126,6 @@
       <Project>{252ce1c2-027a-4445-a3c2-e4d6c80a935a}</Project>
       <Name>Splat-Net45</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Akavache.Sqlite3\Akavache.Sqlite3.csproj">
-      <Project>{241c47df-ca8e-4296-aa03-2c48bb646abd}</Project>
-      <Name>Akavache.Sqlite3</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Having it be PCL meant that we had to have both a PCL and .netfx version of Splat, which was causing problems with test runners because the would load the wrong version of the library at random in some
situations.